### PR TITLE
Update and rename genesis_29-2.json to genesis_29.json

### DIFF
--- a/cosmos/genesis_29.json
+++ b/cosmos/genesis_29.json
@@ -2,7 +2,7 @@
   "rpc": "https://26657.genesisl1.org/",
   "rest": "https://api.genesisl1.org/",
   "chainId": "genesis_29-2",
-  "chainName": "GenesisL1",
+  "chainName": "Genesis L1",
   "chainSymbolImageUrl": "https://raw.githubusercontent.com/alpha-omega-labs/genesisd/neolithic/L1.png",
   "stakeCurrency": {
     "coinDenom": "L1",
@@ -44,5 +44,10 @@
   "features": [
     "eth-address-gen",
     "eth-key-sign"
-  ]
+  ],
+  "nodeProvider": {
+    "name": "Genesis L1",
+    "email": "info@genesisl1.com",
+    "website":"https://genesisl1.com/"
+  },
 }


### PR DESCRIPTION
Hey, this is for the keplr-chain-registry PR you've made a while back. Two things need to be checked/changed:

1. The chain name is set to `Genesis L1`, but it might be `GenesisL1` I wasn't sure anymore what the correct way to write the project was. It's in two places: `chainName` and `nodeProvider -> name` where this has to be double-checked and changed or not.
2. I inserted a dummy email `info@genesisl1.com`, will have to be changed to a real one.

After merging and changing these I believe you could alert the keplr people to add the chain to their registry again via the PR you made back then!

Bye :)!